### PR TITLE
extended by the possibility to hide header.innerHTML

### DIFF
--- a/MMM-DWD-WarnWeather.js
+++ b/MMM-DWD-WarnWeather.js
@@ -8,6 +8,9 @@
  *
  * extended by the possibility to only request warnings higher than a certain warning level
  * By @spitzlbergerj
+ *
+ * extended by the possibility to hide header.innerHTML
+ * By @spitzlbergerj
  */
 
 Module.register("MMM-DWD-WarnWeather", {
@@ -24,7 +27,9 @@ Module.register("MMM-DWD-WarnWeather", {
 		loadingText: 'Warnungen werden geladen...',
 		noWarningText: 'Keine Warnungen',
 		noWarningTextGreater: ' ab Warnstufe Level ',
-		severityThreshold: 1
+		severityThreshold: 1,
+		// hide header.innerHTML
+		displayInnerHeader: true,
 	},
 	// Required scrpits
 	getScripts: function () {
@@ -77,16 +82,23 @@ Module.register("MMM-DWD-WarnWeather", {
 		var wrapper = document.createElement("div");
 		wrapper.className = 'wrapper';
 
+		// @spitzlbergerj: possibility to hide inner header
+		// with separation of header and "Location not found"
 		var header = document.createElement("header");
-		if (this.community.hasOwnProperty('properties')){
-			header.innerHTML = 'Wetterwarnungen';
-			if (this.config.displayRegionName && this.loaded) {
-				header.innerHTML += ' für:<br>' + this.community.properties.NAME;
-			}
-		} else {
-			header.innerHTML = 'Ort nicht gefunden';
+		header.innerHTML = 'Wetterwarnungen';
+		if (this.config.displayRegionName && this.loaded) {
+			header.innerHTML += ' für:<br>' + this.community.properties.NAME;
 		}
-		wrapper.appendChild(header);
+		if (this.config.displayInnerHeader) {
+			wrapper.appendChild(header);
+		}
+
+		var locNotFound = document.createElement("div");
+		locNotFound.className = 'locationNotFound';
+		if (! this.community.hasOwnProperty('properties')){
+			locNotFound.innerHTML = 'Ort nicht gefunden';
+			wrapper.appendChild(locNotFound);
+		}
 
 		// Check if warning data was loaded
 		if (!this.loaded) {
@@ -150,6 +162,7 @@ Module.register("MMM-DWD-WarnWeather", {
 
 		}
 
+		//Log.info(wrapper);
 		return wrapper;
 	},
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The entry in `config.js` can include the following options:
 |`loadingText`|The text used while loading warnings.<br><br>**Default value:** `'Warnungen werden geladen...'`|
 |`noWarningText`|The text used when there are no warnings for your region.<br><br>**Default value:** `'Keine Warnungen'`|
 |`severityThreshold`|The warning level at which the weather warnings are to be displayed.<br><br>**Type:** Integer, **Values:** 1, 2, 3, 4<br>**Default value:** `1`|
+|`displayInnerHeader`|Display a second header line with the text "Wetterwarnungen" appended by the region if displayRegionName is set to true.<br><br>**Type:** boolean, **Values:** true, false<br>**Default value:** `true`|
 
 
 Here is an example of an entry in `config.js`
@@ -42,6 +43,7 @@ Here is an example of an entry in `config.js`
 		changeColor: true,
 		minutes: false,
 		displayRegionName: true,
+		displayInnerHeader: true,
 		interval: 10 * 60 * 1000, // every 10 minutes
 		loadingText: 'Warnungen werden geladen...',
 		noWarningText: 'Keine Warnungen',


### PR DESCRIPTION
I have introduced another parameter displayInnerHeader, with which the second header line can be switched on or off. In this turn I separated the display "Location not found" from the display of the second header line.