### PR TITLE
Fixing header display error for #29

### DIFF
--- a/MMM-DWD-WarnWeather.js
+++ b/MMM-DWD-WarnWeather.js
@@ -163,16 +163,16 @@ Module.register("MMM-DWD-WarnWeather", {
 			var duration = document.createElement("div");
 			duration.className = 'duration';
 			duration.innerHTML = start + ' - ' + end;
-			var newLine1 = document.createElement("br");
-			var newLine2 = document.createElement("br");
+			var newLineSingleWarning = document.createElement("br");
+			var newLineMultipleWarning = document.createElement("br");
 			description.appendChild(headline);
 			description.appendChild(duration);
 			warnWrapper.appendChild(icon);
 			warnWrapper.appendChild(description);
 			wrapper.appendChild(warnWrapper);
-			wrapper.appendChild(newLine1);
+			wrapper.appendChild(newLineSingleWarning);
 			if (this.warnings.length > 1) {
-			    wrapper.appendChild(newLine2);
+			    wrapper.appendChild(newLineMultipleWarning);
 			}
 		}
 


### PR DESCRIPTION
Fixing an error for #29 where the header of the module was hidden even if there was a weather warning.